### PR TITLE
Feature/search TagId 기준 Social 검색 기능 구현

### DIFF
--- a/src/main/java/com/sideproject/sideproject/search/Search.java
+++ b/src/main/java/com/sideproject/sideproject/search/Search.java
@@ -1,5 +1,0 @@
-package com.sideproject.sideproject.search;
-
-//삭제 후 진행
-public class Search {
-}

--- a/src/main/java/com/sideproject/sideproject/search/controller/SearchSocialController.java
+++ b/src/main/java/com/sideproject/sideproject/search/controller/SearchSocialController.java
@@ -1,5 +1,6 @@
 package com.sideproject.sideproject.search.controller;
 
+import com.sideproject.sideproject.global.response.ErrorResponseDTO;
 import com.sideproject.sideproject.global.response.ResponseDTO;
 import com.sideproject.sideproject.search.dto.SearchSocialResponseDTO;
 import com.sideproject.sideproject.search.service.Impl.SearchSocialServiceImpl;
@@ -25,17 +26,17 @@ public class SearchSocialController {
     public ResponseDTO<?> doSearchSocialByTag(@PathVariable Long tagNum) {
         List<SearchSocialResponseDTO> list = service.selectSocialByTag(tagNum);
 
-        ResponseDTO<List<SearchSocialResponseDTO>> responseDTO;
+        ResponseDTO<?> responseDTO;
         try {
             if (Objects.isNull(list) || list.isEmpty()) {
-                responseDTO = new ResponseDTO<>(500, "failed", "응답 실패");
+                ErrorResponseDTO errorResponseDTO= new ErrorResponseDTO(500, "응답 성공같은 실패?");
+                responseDTO = new ResponseDTO<>(errorResponseDTO);
             } else {
-                responseDTO = new ResponseDTO<>(200, "success", "응답 성공");
+                responseDTO = new ResponseDTO<>(list);
             }
         } catch (Exception e) {
             return null;
         }
-        responseDTO.setData(list);
 
         return responseDTO;
 

--- a/src/main/java/com/sideproject/sideproject/search/controller/SearchSocialController.java
+++ b/src/main/java/com/sideproject/sideproject/search/controller/SearchSocialController.java
@@ -1,0 +1,43 @@
+package com.sideproject.sideproject.search.controller;
+
+import com.sideproject.sideproject.global.response.ResponseDTO;
+import com.sideproject.sideproject.search.dto.SearchSocialResponseDTO;
+import com.sideproject.sideproject.search.service.Impl.SearchSocialServiceImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Objects;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "search", description = "검색 API")
+public class SearchSocialController {
+
+    private final SearchSocialServiceImpl service;
+
+    @GetMapping("/social/search/{tagNum}")
+    @Operation(summary = "태그 검색 기능", description = "모임 게시글 태그 검색 api")
+    public ResponseDTO<?> doSearchSocialByTag(@PathVariable Long tagNum) {
+        List<SearchSocialResponseDTO> list = service.selectSocialByTag(tagNum);
+
+        ResponseDTO<List<SearchSocialResponseDTO>> responseDTO;
+        try {
+            if (Objects.isNull(list) || list.isEmpty()) {
+                responseDTO = new ResponseDTO<>(500, "failed", "응답 실패");
+            } else {
+                responseDTO = new ResponseDTO<>(200, "success", "응답 성공");
+            }
+        } catch (Exception e) {
+            return null;
+        }
+        responseDTO.setData(list);
+
+        return responseDTO;
+
+    }
+}

--- a/src/main/java/com/sideproject/sideproject/search/dto/SearchCommentResponseDTO.java
+++ b/src/main/java/com/sideproject/sideproject/search/dto/SearchCommentResponseDTO.java
@@ -1,0 +1,35 @@
+package com.sideproject.sideproject.search.dto;
+
+import com.sideproject.sideproject.comment.domain.Comment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class SearchCommentResponseDTO {
+    private String id;
+
+    private SearchUserResponseDTO searchUserResponseDTO;
+
+    private SearchPostResponseDTO searchPostResponseDTO;
+
+    private String content;
+
+
+    @Builder
+    public SearchCommentResponseDTO(Comment comment){
+        this.searchUserResponseDTO = new SearchUserResponseDTO(comment.getUser());
+        this.searchPostResponseDTO = new SearchPostResponseDTO(comment.getPost());
+        this.id = String.valueOf(comment.getId());
+        this.content = comment.getContent();
+    }
+
+    static public List<SearchCommentResponseDTO> SearchCommentResponseDTO(List<Comment> list){
+        return new ArrayList<>(list.stream()
+                .map(SearchCommentResponseDTO::new)
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/sideproject/sideproject/search/dto/SearchPostResponseDTO.java
+++ b/src/main/java/com/sideproject/sideproject/search/dto/SearchPostResponseDTO.java
@@ -1,0 +1,38 @@
+package com.sideproject.sideproject.search.dto;
+
+import com.sideproject.sideproject.post.domain.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SearchPostResponseDTO {
+    private String id;
+
+    private String contents;
+
+    private String regionCode;
+
+    private String dongCode;
+
+    private String dongName;
+
+    private String likes;
+
+    @Builder
+    public SearchPostResponseDTO(String id, String contents, String regionCode, String dongCode, String dongName, String likes) {
+        this.id = id;
+        this.contents = contents;
+        this.regionCode = regionCode;
+        this.dongCode = dongCode;
+        this.dongName = dongName;
+        this.likes = likes;
+    }
+    public SearchPostResponseDTO(Post post) {
+        this.id = String.valueOf(post.getId());
+        this.contents = post.getContents();
+        this.regionCode = String.valueOf(post.getRegionCode());
+        this.dongCode = post.getDongName();
+        this.dongName = post.getDongName();
+        this.likes = String.valueOf(post.getLikes());
+    }
+}

--- a/src/main/java/com/sideproject/sideproject/search/dto/SearchSocialResponseDTO.java
+++ b/src/main/java/com/sideproject/sideproject/search/dto/SearchSocialResponseDTO.java
@@ -1,0 +1,61 @@
+package com.sideproject.sideproject.search.dto;
+
+import com.sideproject.sideproject.social.domain.Social;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class SearchSocialResponseDTO {
+
+    private String title;
+
+    private String hits;
+
+    private String startDate;
+
+    private String endDate;
+
+    private String currentNums;
+
+    private String limitedNums;
+
+    private String contact;
+
+    private SearchPostResponseDTO searchPostResponseDTO;
+
+    private SearchUserResponseDTO searchUserResponseDTO;
+
+    private List<SearchCommentResponseDTO> searchCommentResponseDTO;
+
+    @Builder
+    public SearchSocialResponseDTO(Social social){
+        searchUserResponseDTO = new SearchUserResponseDTO(social.getUser());
+        searchPostResponseDTO = new SearchPostResponseDTO(String.valueOf(
+                social.getId()),
+                social.getContents(),
+                String.valueOf(social.getRegionCode()),
+                String.valueOf(social.getDongCode()),
+                social.getDongName(),
+                String.valueOf(social.getLikes())
+        );
+        searchCommentResponseDTO = SearchCommentResponseDTO.SearchCommentResponseDTO(social.getComments());
+
+        this.title = social.getTitle();
+        this.hits = String.valueOf(social.getHits());
+        this.startDate = String.valueOf(social.getStartDate());
+        this.endDate = String.valueOf(social.getEndDate());
+        this.currentNums = String.valueOf(social.getCurrentNums());
+        this.limitedNums = String.valueOf(social.getLimitedNums());
+        this.contact = social.getContact();
+    }
+
+    static public List<SearchSocialResponseDTO> SearchSocialResponseDTO(List<Social> socialList){
+        return new ArrayList<>(socialList.stream()
+                .map(SearchSocialResponseDTO::new)
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/sideproject/sideproject/search/dto/SearchUserResponseDTO.java
+++ b/src/main/java/com/sideproject/sideproject/search/dto/SearchUserResponseDTO.java
@@ -1,6 +1,6 @@
 package com.sideproject.sideproject.search.dto;
 
-import com.sideproject.sideproject.customer.domain.User;
+import com.sideproject.sideproject.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/sideproject/sideproject/search/dto/SearchUserResponseDTO.java
+++ b/src/main/java/com/sideproject/sideproject/search/dto/SearchUserResponseDTO.java
@@ -1,0 +1,30 @@
+package com.sideproject.sideproject.search.dto;
+
+import com.sideproject.sideproject.customer.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SearchUserResponseDTO {
+    private String id;
+
+    private String email;
+
+    private String username;
+
+    private String nickname;
+
+    private String dongCode;
+
+    private String dongName;
+
+    @Builder
+    public SearchUserResponseDTO(User user){
+        this.id = String.valueOf(user.getId());
+        this.email = user.getEmail();
+        this.username = user.getUsername();
+        this.nickname = user.getNickname();
+        this.dongCode = String.valueOf(user.getDongCode());
+        this.dongName = user.getDongName();
+    }
+}

--- a/src/main/java/com/sideproject/sideproject/search/repository/SearchSocialRepository.java
+++ b/src/main/java/com/sideproject/sideproject/search/repository/SearchSocialRepository.java
@@ -1,0 +1,16 @@
+package com.sideproject.sideproject.search.repository;
+
+import com.sideproject.sideproject.social.domain.Social;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface SearchSocialRepository extends JpaRepository<Social, Long> {
+
+    @Query("SELECT s FROM Social s WHERE s.id IN " +
+            "(SELECT st.social.id from SocialTag st where st.tag.id = :tagNum )")
+    List<Social> findByTagId(@Param("tagNum") Long tagNum);
+
+}

--- a/src/main/java/com/sideproject/sideproject/search/service/Impl/SearchSocialServiceImpl.java
+++ b/src/main/java/com/sideproject/sideproject/search/service/Impl/SearchSocialServiceImpl.java
@@ -1,0 +1,26 @@
+package com.sideproject.sideproject.search.service.Impl;
+
+import com.sideproject.sideproject.search.dto.SearchSocialResponseDTO;
+import com.sideproject.sideproject.search.repository.SearchSocialRepository;
+import com.sideproject.sideproject.search.service.SearchSocialService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SearchSocialServiceImpl implements SearchSocialService {
+
+    private final SearchSocialRepository repository;
+
+    @Override
+    public List<SearchSocialResponseDTO> selectSocialByTag(Long tagNum) {
+
+        return SearchSocialResponseDTO
+                .SearchSocialResponseDTO(repository.findByTagId(tagNum));
+
+    }
+}

--- a/src/main/java/com/sideproject/sideproject/search/service/SearchSocialService.java
+++ b/src/main/java/com/sideproject/sideproject/search/service/SearchSocialService.java
@@ -1,0 +1,9 @@
+package com.sideproject.sideproject.search.service;
+
+import com.sideproject.sideproject.search.dto.SearchSocialResponseDTO;
+
+import java.util.List;
+
+public interface SearchSocialService {
+    public List<SearchSocialResponseDTO> selectSocialByTag (Long tagId);
+}


### PR DESCRIPTION
## Why need this change? 
- Tag Id 를 기준으로 Social 게시글 검색하는 기능 추가

## Changes ✏️
- #18 
  - 6ca07ad : 검색 후 Social 게시글 목록 List 반환을 위해 Social Entitiy 와 관련된  Search[관련Entity]ResponseDTO 생성
  - c22e99f25cac329ab0f22f763110039fb9a4480e : DB 에서 Tag ID 가 일치하는 Social 목록을 검색하기 위한 Repository 생성
  - 4daa4aea6caa9906784ab71e110bfbf042b602cf : DB 에서 반환된 List<Social> 을 생성한 SearchSocialResponseDTO 타입으로 변환하는 Service 생성
  - 102173c2fe5d78712d24122b1da087e1806285f6 : TagID 입력 및 View 에 Data 반환을 위해 ResponseDTO 형식으로 변환 및 반환

- 8aea925d1ee49937cb52686a3886cea7b3628096 : 패키지 경로가 Customer -> User 로 변경되어 이를 사용하는 DTO 의 Import 경로 변경
- d7c6c2a59938425fa9a09ea8d848f99cbb247481 : ResponseDTO 사용 방식이 변경되어 이에 맞도록 Controller 수정

## Test checklist✅ (optional)
- Swagger 로 Social Data 검색 테스트 완료
