### PR TITLE
Feature/like 좋아요 개수, 좋아요 누른 유저 보여주는 기능 구현

### DIFF
--- a/src/main/java/com/sideproject/sideproject/feed/domain/Feed.java
+++ b/src/main/java/com/sideproject/sideproject/feed/domain/Feed.java
@@ -18,7 +18,4 @@ public class Feed extends Post {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "social_id")
     private Social social; //작성자가 참여 중인 모임 연결
-
-    @Transient
-    private boolean liked;
 }

--- a/src/main/java/com/sideproject/sideproject/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/sideproject/sideproject/global/exception/CustomExceptionHandler.java
@@ -2,11 +2,14 @@ package com.sideproject.sideproject.global.exception;
 
 import com.sideproject.sideproject.comment.exception.GlobalException;
 import com.sideproject.sideproject.comment.exception.GlobalExceptionType;
-import com.sideproject.sideproject.user.exception.UserException;
 import com.sideproject.sideproject.global.response.ErrorResponseDTO;
+import com.sideproject.sideproject.post.exception.PostException;
+import com.sideproject.sideproject.user.exception.UserException;
 import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import javax.validation.ConstraintViolationException;
@@ -14,13 +17,22 @@ import javax.validation.ConstraintViolationException;
 @RestControllerAdvice
 public class CustomExceptionHandler implements ErrorController {
 
-//    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    //    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(value = UserException.class)
-    public ErrorResponseDTO handleUserException(CustomException ex){
+    public ErrorResponseDTO handleUserException(CustomException ex) {
 //        ErrorResponseDTO errorResponse = new ErrorResponseDTO(ex.getCustomExceptionType());
         return ErrorResponseDTO.builder()
                 .errorCode(ex.getCustomExceptionType().getErrorCode())
                 .message(ex.getCustomExceptionType().getErrorMsg())
+                .build();
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler
+    public ErrorResponseDTO handlePostException(PostException e) {
+        return ErrorResponseDTO.builder()
+                .errorCode(e.getCustomExceptionType().getErrorCode())
+                .message(e.getCustomExceptionType().getErrorMsg())
                 .build();
     }
 

--- a/src/main/java/com/sideproject/sideproject/global/response/ResponseDTO.java
+++ b/src/main/java/com/sideproject/sideproject/global/response/ResponseDTO.java
@@ -18,7 +18,7 @@ public class ResponseDTO<T> {
     @Schema(name = "result message", example = "응답 성공")
     private String message;
 
-    @Schema(name = "result date", example = "{name = '철수김', age = '25세'}")
+    @Schema(name = "result data", example = "{name = '철수김', age = '25세'}")
     private T data;
 
     public ResponseDTO(T data) {

--- a/src/main/java/com/sideproject/sideproject/like/controller/LikeController.java
+++ b/src/main/java/com/sideproject/sideproject/like/controller/LikeController.java
@@ -20,6 +20,7 @@ public class LikeController {
     private final LikeService likeService;
 
     @GetMapping("/{postId}")
+    @Operation(summary = "좋아요 개수", description = "해당 포스트의 좋아요 개수를 나타낸다")
     public ResponseDTO getLikes(@PathVariable Long postId) {
         return new ResponseDTO<Integer>(likeService.displayLikes(postId));
     }
@@ -41,6 +42,7 @@ public class LikeController {
     }
 
     @GetMapping("/{postId}/liked-users")
+    @Operation(summary = "좋아요 누른 유저들", description = "해당 포스트에 좋아요를 누른 유저들의 정보를 나타낸다")
     public ResponseDTO getLikedUsers(@PathVariable Long postId) {
         if (likeService.displayLikes(postId) > 0) {
             return new ResponseDTO<List<UserResponseDTO>>(likeService.displayLikedUsers(postId));

--- a/src/main/java/com/sideproject/sideproject/like/controller/LikeController.java
+++ b/src/main/java/com/sideproject/sideproject/like/controller/LikeController.java
@@ -17,8 +17,8 @@ public class LikeController {
     private final LikeService likeService;
 
     @GetMapping("/{postId}")
-    public ResponseDTO displayLikes(@PathVariable Long postId) {
-        return new ResponseDTO(likeService.displayLikes(postId));
+    public ResponseDTO getLikes(@PathVariable Long postId) {
+        return new ResponseDTO<Integer>(likeService.displayLikes(postId));
     }
 
     @PostMapping("/{postId}")
@@ -34,6 +34,6 @@ public class LikeController {
                 .isLiked(isLiked)
                 .build();
 
-        return new ResponseDTO(likeResponseDto);
+        return new ResponseDTO<LikeResponseDto>(likeResponseDto);
     }
 }

--- a/src/main/java/com/sideproject/sideproject/like/controller/LikeController.java
+++ b/src/main/java/com/sideproject/sideproject/like/controller/LikeController.java
@@ -3,10 +3,13 @@ package com.sideproject.sideproject.like.controller;
 import com.sideproject.sideproject.global.response.ResponseDTO;
 import com.sideproject.sideproject.like.dto.LikeResponseDto;
 import com.sideproject.sideproject.like.service.LikeService;
+import com.sideproject.sideproject.user.dto.UserResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,5 +38,13 @@ public class LikeController {
                 .build();
 
         return new ResponseDTO<LikeResponseDto>(likeResponseDto);
+    }
+
+    @GetMapping("/{postId}/liked-users")
+    public ResponseDTO getLikedUsers(@PathVariable Long postId) {
+        if (likeService.displayLikes(postId) > 0) {
+            return new ResponseDTO<List<UserResponseDTO>>(likeService.displayLikedUsers(postId));
+        } else return ResponseDTO.empty();
+        //사실 likes가 1 이상이면 exception handler에 걸려서 else문은 통과하지 않는데 이부분을 어떻게 해야될지 고민
     }
 }

--- a/src/main/java/com/sideproject/sideproject/like/controller/LikeController.java
+++ b/src/main/java/com/sideproject/sideproject/like/controller/LikeController.java
@@ -1,5 +1,6 @@
 package com.sideproject.sideproject.like.controller;
 
+import com.sideproject.sideproject.global.response.ResponseDTO;
 import com.sideproject.sideproject.like.dto.LikeResponseDto;
 import com.sideproject.sideproject.like.service.LikeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,17 +16,24 @@ public class LikeController {
 
     private final LikeService likeService;
 
+    @GetMapping("/{postId}")
+    public ResponseDTO displayLikes(@PathVariable Long postId) {
+        return new ResponseDTO(likeService.displayLikes(postId));
+    }
+
     @PostMapping("/{postId}")
-    @Operation(summary = "좋아요 버튼",description = "좋아요가 없는 상태에서 실행하면 생기고 반대면 사라진다")
+    @Operation(summary = "좋아요 버튼", description = "좋아요가 없는 상태에서 실행하면 생기고 반대면 사라진다")
     //일단은 RequestParam으로 userId 받았다가 나중에 로그인 합쳐지면 변경예정
     //아마 @AuthenticationPrincipal 써야되는거 같음?
-    public LikeResponseDto setLike(@PathVariable Long postId, @RequestParam Long userId) {
-        boolean isLiked = likeService.likeButton(userId, postId);
+    public ResponseDTO setLike(@PathVariable Long postId, @RequestParam Long userId) {
 
-        return LikeResponseDto.builder()
+        boolean isLiked = likeService.likeButton(userId, postId);
+        LikeResponseDto likeResponseDto = LikeResponseDto.builder()
                 .userId(userId)
                 .postId(postId)
                 .isLiked(isLiked)
                 .build();
+
+        return new ResponseDTO(likeResponseDto);
     }
 }

--- a/src/main/java/com/sideproject/sideproject/like/domain/Like.java
+++ b/src/main/java/com/sideproject/sideproject/like/domain/Like.java
@@ -28,12 +28,12 @@ public class Like {
 
 
     @Builder
-    private Like(User user, Post post){
+    private Like(User user, Post post) {
         this.user = user;
         this.post = post;
     }
 
-    public static Like createLike(User user, Post post){
+    public static Like createLike(User user, Post post) {
         Like like = Like.builder().user(user).post(post).build();
         return like;
     }

--- a/src/main/java/com/sideproject/sideproject/like/repository/LikeRepository.java
+++ b/src/main/java/com/sideproject/sideproject/like/repository/LikeRepository.java
@@ -3,6 +3,9 @@ package com.sideproject.sideproject.like.repository;
 import com.sideproject.sideproject.like.domain.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
@@ -11,6 +14,10 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     List<Like> findAllByUserId(Long userId);
     List<Like> findAllByPostId(Long postId);
     */
+
+    @Query("SELECT l FROM Like l join fetch l.user u where l.post.id = :postId")
+        //db에 없는 postId일때의 예외처리 필요할듯?
+    List<Like> findAllByPostId(Long postId);
 
     @Modifying
     void deleteByUserIdAndPostId(Long userId, Long postId);

--- a/src/main/java/com/sideproject/sideproject/like/service/LikeService.java
+++ b/src/main/java/com/sideproject/sideproject/like/service/LikeService.java
@@ -44,4 +44,11 @@ public class LikeService {
             return false;
         }
     }
+
+    public Integer displayLikes(Long postId) {
+
+        Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(PostExceptionType.NON_EXISTENT_POST));
+
+        return post.getLikes();
+    }
 }

--- a/src/main/java/com/sideproject/sideproject/like/service/LikeService.java
+++ b/src/main/java/com/sideproject/sideproject/like/service/LikeService.java
@@ -7,12 +7,17 @@ import com.sideproject.sideproject.post.exception.PostException;
 import com.sideproject.sideproject.post.exception.PostExceptionType;
 import com.sideproject.sideproject.post.repository.PostRepository;
 import com.sideproject.sideproject.user.domain.User;
+import com.sideproject.sideproject.user.dto.UserResponseDTO;
 import com.sideproject.sideproject.user.exception.UserException;
 import com.sideproject.sideproject.user.exception.UserExceptionType;
 import com.sideproject.sideproject.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 @Service
 @Transactional(readOnly = true)
@@ -50,5 +55,15 @@ public class LikeService {
         Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(PostExceptionType.NON_EXISTENT_POST));
 
         return post.getLikes();
+    }
+
+    public List<UserResponseDTO> displayLikedUsers(Long postId) {
+        return likeRepository.findAllByPostId(postId)
+                .stream()
+                .map(Like::getUser)
+                .map(UserResponseDTO::new)
+                //일단은 USerResponseDTO로 반환하고
+                //나중에 email이나 id만 반환하는 DTO를 새로 만드는 방식도 고려
+                .collect(toList());
     }
 }

--- a/src/main/java/com/sideproject/sideproject/post/repository/PostRepository.java
+++ b/src/main/java/com/sideproject/sideproject/post/repository/PostRepository.java
@@ -3,5 +3,9 @@ package com.sideproject.sideproject.post.repository;
 import com.sideproject.sideproject.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Optional<Post> findById(Long id);
 }


### PR DESCRIPTION
## Why need this change? 
- PostRepository 생성
- 좋아요 개수 보여주는 기능 구현
- 좋아요 누른 유저들을 보여주는 기능 구현

## Changes ✏️
- https://github.com/KDT-study-team1/side-project/issues/13
    - cf54a347c4951eaa828f9a43190c066e7ade1e9b : 좋아요 개수 출력에 필요한 PostRepository 생성
    - f553ad649b5ea2187a2d4fd1d63c699da4830041, 3f167e2544c4ac09a33a52c9ebcbf92d5f5ff7a6 : 좋아요 개수를 출력하는데 필요한 로직 controller와 service에 추가 
    - 49efd815f7f6d54ff492fbd88f870b2742864e93, 4564dbe9751787de5ad92be0d3630845d509cf8c, c32dba100d41fc72301e51e1481a828fa12af3af : 좋아요 누른 유저들을 출력하는데 필요한 로직 repository, controller, service에 추가
 - 0caec0e69353bcefee8dc307bf169884e9ddee0f : Feed Entity의 불필요한 멤버 liked 삭제
 - 그 외 스웨거 설명 추가
 - 컨트롤러와 service의 메소드 명이 중복되는거 같아 중복되는 경우 컨트롤러에 get~, post~ 로 네이밍 수정


 

## Test checklist✅ (optional)
- 테스트 계획 또는 완료 사항을 기재합니다.
